### PR TITLE
Add unit testing support to plugin

### DIFF
--- a/src/main/kotlin/edu/wpi/first/desktop/jlink/JLinkExtension.kt
+++ b/src/main/kotlin/edu/wpi/first/desktop/jlink/JLinkExtension.kt
@@ -1,0 +1,15 @@
+package edu.wpi.first.desktop.jlink
+
+import org.gradle.api.NamedDomainObjectCollection
+import org.gradle.api.Project
+import javax.inject.Inject
+
+open class JLinkExtension
+@Inject
+internal constructor(
+        project: Project
+) {
+    val configure: NamedDomainObjectCollection<JLinkOptions> = project.container(JLinkOptions::class.java) { name ->
+        JLinkOptions(name = name)
+    }
+}

--- a/src/main/kotlin/edu/wpi/first/desktop/jlink/JLinkPlugin.kt
+++ b/src/main/kotlin/edu/wpi/first/desktop/jlink/JLinkPlugin.kt
@@ -2,25 +2,19 @@ package edu.wpi.first.desktop.jlink
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.create
 
-class JLinkPlugin : Plugin<Project> {
+open class JLinkPlugin : Plugin<Project> {
 
     companion object {
         const val EXTENSION_NAME = "jlink"
         const val JLINK_TASK_GROUP = "JLink"
-        const val JLINK_TASK_NAME = "jlink"
+        const val JLINK_TASK_NAME = "jlinkGenerate"
         const val JLINK_ZIP_TASK_NAME = "jlinkZip"
     }
 
     override fun apply(project: Project) {
-        println("Applying jlink plugin to $project")
-        val container = project.container(JLinkOptions::class.java) { name ->
-            require(name.isNotBlank()) {
-                "Name of ${JLinkOptions::class.simpleName} must be specified"
-            }
-            JLinkOptions(name = name)
-        }
-        project.extensions.add(EXTENSION_NAME, container)
+        val extension = project.extensions.create(EXTENSION_NAME, JLinkExtension::class, project)
 
         val jlinkTask = project.tasks.register(JLINK_TASK_NAME) {
             group = JLINK_TASK_GROUP

--- a/src/test/kotlin/edu/wpi/first/desktop/jlink/AbstractPluginTest.kt
+++ b/src/test/kotlin/edu/wpi/first/desktop/jlink/AbstractPluginTest.kt
@@ -1,0 +1,87 @@
+package edu.wpi.first.desktop.jlink
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.util.TextUtil.normaliseFileSeparators
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junitpioneer.jupiter.TempDirectory
+import java.io.File
+import java.nio.file.Path
+import java.util.*
+
+@ExtendWith(TempDirectory::class)
+abstract class AbstractPluginTest {
+
+    private lateinit var tempDir: Path
+
+    @BeforeEach
+    fun beforeEach(@TempDirectory.TempDir tempDir: Path) {
+        this.tempDir = tempDir
+    }
+
+    val projectRoot: File
+        get() = tempDir.toFile().resolve("plugin-test").apply { mkdirs() }
+
+    protected
+    fun buildscriptBlockWithUnderTestPlugin() =
+        """
+        buildscript {
+            repositories { maven { setUrl("$testRepositoryPath") } }
+            dependencies {
+                classpath("edu.wpi.first.desktop:platform-releases:${testProperties["version"]}")
+            }
+        }
+        """.trimIndent()
+
+    protected
+    fun pluginsBlockWithKotlinJvmPlugin() =
+        """
+        plugins {
+            id("org.jetbrains.kotlin.jvm") version "${testProperties["kotlinVersion"]}"
+        }
+        """.trimIndent()
+
+    protected
+    fun kotlinExtensionAccessor() =
+        """
+        fun `${JLinkPlugin.EXTENSION_NAME}`(configure: ${JLinkExtension::class.qualifiedName}.() -> Unit): Unit =
+            (this as org.gradle.api.plugins.ExtensionAware).extensions.configure("${JLinkPlugin.EXTENSION_NAME}", configure)
+        """.trimIndent()
+
+    protected
+    fun build(vararg arguments: String): BuildResult =
+            gradleRunnerFor(*arguments).forwardOutput().build()
+
+    protected
+    fun buildAndFail(vararg arguments: String): BuildResult =
+            gradleRunnerFor(*arguments).forwardOutput().buildAndFail()
+
+    protected
+    fun gradleRunnerFor(vararg arguments: String): GradleRunner =
+            GradleRunner.create()
+                    .withProjectDir(projectRoot)
+                    .withArguments(arguments.toList())
+
+    private
+    val testRepositoryPath
+        get() = normaliseFileSeparators(File("build/plugin-test-repository").absolutePath)
+
+    protected
+    val testProperties: Properties by lazy {
+        javaClass.getResourceAsStream("/test.properties").use {
+            Properties().apply { load(it) }
+        }
+    }
+
+    private
+    fun File.createSourceFile(sourceFilePath: String, contents: String) {
+        val sourceFile = resolve(sourceFilePath)
+        sourceFile.parentFile.mkdirs()
+        sourceFile.writeText(contents)
+    }
+
+    fun File.buildFile() = resolve("build.gradle")
+    fun File.buildKotlinFile() = resolve("build.gradle.kts")
+    fun File.settingsFile() = resolve("settings.gradle")
+}

--- a/src/test/kotlin/edu/wpi/first/desktop/jlink/JLinkPluginTest.kt
+++ b/src/test/kotlin/edu/wpi/first/desktop/jlink/JLinkPluginTest.kt
@@ -1,0 +1,36 @@
+package edu.wpi.first.desktop.jlink
+
+import org.gradle.api.NamedDomainObjectCollection
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class JLinkPluginTest: AbstractPluginTest() {
+    @Test
+    fun `can access the jlink extension`() {
+        projectRoot.apply {
+            buildKotlinFile().writeText(
+                """
+                ${buildscriptBlockWithUnderTestPlugin()}
+
+                ${pluginsBlockWithKotlinJvmPlugin()}
+
+                apply(plugin = "edu.wpi.first.desktop.platform-releases")
+
+                // This extension should have been added by the accessor below.
+                jlink {
+                    assert(this is ${JLinkExtension::class.qualifiedName})
+                    configure {
+                        assert(this is ${NamedDomainObjectCollection::class.qualifiedName}<*>)
+                    }
+                }
+
+                ${kotlinExtensionAccessor()}
+                """.trimIndent()
+            )
+        }
+        build("tasks").apply {
+            assertEquals(TaskOutcome.SUCCESS, task(":tasks")!!.outcome)
+        }
+    }
+}


### PR DESCRIPTION
Now we can unit test.
In order to run the unit tests in the IDE you must launch them with IJ's gradle test launcher. They won't work with IJ's built in launcher.